### PR TITLE
replace tailf by slice-file, variable naming

### DIFF
--- a/lib/orders/node_log.js
+++ b/lib/orders/node_log.js
@@ -1,12 +1,14 @@
 'use strict';
 
 var path = require('path');
-var spawn = require('child_process').spawn;
 var exec = require('child_process').exec;
+var through = require('through2')
+var sf = require('slice-file');
+
 
 var buffered = [];
 exports.logdir = ''; // 日志路径
-var tail;
+var xs;
 
 var date = function(now) {
   if (!now) {
@@ -47,11 +49,12 @@ function getLogFileInfo() {
 }
 
 function startTailf(path) {
-  var tail = spawn('tail', ['-f', path]);
-  tail.stdout.on("data", function (data) {
-    buffered.push(data);
-  });
-  return tail;
+  var xs = sf(path);
+  var t = xs.follow(-1).pipe(through(function(line, _, next){
+    buffered.push(line);
+    next();
+  }));
+  return xs;
 }
 
 var patt = /\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{6}\] \[(.+)\] \[(.+)\] \[(\d+)\] (.*)/g;
@@ -83,17 +86,17 @@ function getNodeLog() {
   return result;
 }
 
-var tail;
+
 var init = function () {
   var info = getLogFileInfo();
-  tail = startTailf(info.current);
+  xs = startTailf(info.current);
   exec('touch ' + info.next, function (error, stdout, stderr) {
     if (error) {
       console.log('exec error: ' + error);
     }
   });
   setTimeout(function() {
-    tail.kill();
+    xs.close();
     init();
   }, info.ms_to_refresh);
 };

--- a/lib/orders/system.js
+++ b/lib/orders/system.js
@@ -2,8 +2,8 @@
 
 var os = require('os');
 
-var last_total = 0;
-var last_idle = 0;
+var lastTotal = 0;
+var lastIdle = 0;
 
 var calculateCPU = function () {
   var cpus = os.cpus();
@@ -15,12 +15,12 @@ var calculateCPU = function () {
     idle += time.idle;
   }
 
-  var diff_total = total - last_total;
-  var diff_idle = idle - last_idle;
-  last_total = total;
-  last_idle = idle;
+  var diffTotal = total - lastTotal;
+  var diffIdle = idle - lastIdle;
+  lastTotal = total;
+  lastIdle = idle;
 
-  return 1 - diff_idle / diff_total;
+  return 1 - diffIdle / diffTotal;
 };
 
 var status = function () {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "license": "MIT",
   "dependencies": {
     "ws": "^0.7.2",
-    "debug": "*"
+    "debug": "*",
+    "slice-file": "*",
+    "through2": "^0.6.5"
   },
   "devDependencies": {
     "expect.js": "*",


### PR DESCRIPTION
使用sclie-file库,实现了tailf的功能,不需要去记忆上次的位置,

如果要多文件,那么做法跟http的雷系,多起几个tailf实例,存到{file1: buffer1, file2:buffer2}中就可以了

省去了http中间传输的过程